### PR TITLE
[babel-preset-jolt] Remove all presets, turns this into a plugin-only preset

### DIFF
--- a/packages/babel-preset-jolt/README.md
+++ b/packages/babel-preset-jolt/README.md
@@ -4,13 +4,7 @@
 [![npm](https://img.shields.io/npm/dt/babel-preset-jolt.svg)](https://www.npmjs.com/package/babel-preset-jolt)
 [![npm](https://img.shields.io/npm/l/babel-preset-jolt.svg)](https://github.com/negativetwelve/jolt/blob/master/LICENSE)
 
-Adds default presets:
-
-* babel-preset-es2015
-* babel-preset-es2016
-* babel-preset-es2017
-
-Add default plugins:
+Add the following plugins:
 
 * babel-plugin-transform-builtin-extend
 * babel-plugin-transform-class-properties

--- a/packages/babel-preset-jolt/package.json
+++ b/packages/babel-preset-jolt/package.json
@@ -20,10 +20,7 @@
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-export-extensions": "^6.22.0",
-    "babel-plugin-transform-object-rest-spread": "^6.23.0",
-    "babel-preset-es2015": "^6.24.1",
-    "babel-preset-es2016": "^6.24.1",
-    "babel-preset-es2017": "^6.24.1"
+    "babel-plugin-transform-object-rest-spread": "^6.23.0"
   },
   "scripts": {
     "build": "babel src --out-dir build --ignore '**/*.spec.js'",

--- a/packages/babel-preset-jolt/src/preset.js
+++ b/packages/babel-preset-jolt/src/preset.js
@@ -12,7 +12,7 @@ import pluginTransformObjectRestSpread from 'babel-plugin-transform-object-rest-
 
 
 // eslint-disable-next-line
-export default function (context, options = {}) {
+export default (context, options = {}) => {
   return {
     presets: [
       presetES2015,

--- a/packages/jest-preset-jolt/README.md
+++ b/packages/jest-preset-jolt/README.md
@@ -23,3 +23,9 @@ Add the package as a preset for your jest configuration. In your `package.json`:
   "preset": "jest-preset-jolt"
 }
 ```
+
+*NOTE* If you have a custom `jest` config and you override `setupTestFrameworkScriptFile` in your config, you'll have to import the preset's setup function at the top of your `setupTestFrameworkScriptFile` file:
+
+```javascript
+import 'jest-preset-jolt/setup';
+```


### PR DESCRIPTION
## Issues Fixed

Fix #9 

## Description

## Screenshot

## TODO
